### PR TITLE
Fixes issue where canary releases were missing compiled .js and .d.ts…

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -29,10 +29,24 @@ jobs:
           cd typescript
           npm ci
       
+      - name: Clean dist directory
+        run: |
+          cd typescript
+          rm -rf dist/*
+      
       - name: Build
         run: |
           cd typescript
           npm run build
+      
+      - name: Verify build output
+        run: |
+          cd typescript
+          if [ ! -f "dist/index.js" ] || [ ! -f "dist/index.d.ts" ]; then
+            echo "Build verification failed: Compiled files are missing"
+            exit 1
+          fi
+          echo "Build verification passed: Compiled files exist"
       
       - name: Configure Git
         run: |

--- a/.npmignore
+++ b/.npmignore
@@ -50,4 +50,8 @@ yarn-error.log*
 # Misc
 .DS_Store
 Thumbs.db
-*.tsbuildinfo 
+*.tsbuildinfo
+
+# Ensure dist directory contents are included
+!dist/**/*.js
+!dist/**/*.d.ts 


### PR DESCRIPTION
fix: Ensure compiled files are included in canary releases

- Add explicit rules in .npmignore to include compiled files
- Add build verification step in GitHub Actions workflow
- Clean dist directory before building to prevent stale files
- Add verification step to check for critical compiled files