### PR TITLE
refactor: make Redis dependencies optional with improved error handling

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -73,7 +73,9 @@
     "@aws-sdk/client-s3": "^3.0.0",
     "@aws-sdk/lib-storage": "^3.0.0",
     "@google-cloud/storage": "^7.0.0",
-    "ioredis": "^5.3.2"
+    "ioredis": "^5.0.0",
+    "archiver": "^5.0.0",
+    "extract-zip": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-s3": {
@@ -86,6 +88,12 @@
       "optional": true
     },
     "ioredis": {
+      "optional": true
+    },
+    "archiver": {
+      "optional": true
+    },
+    "extract-zip": {
       "optional": true
     }
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor Redis storage to make `ioredis`, `archiver`, and `extract-zip` optional with improved error handling for dynamic imports.
> 
>   - **Dependencies**:
>     - Mark `ioredis`, `archiver`, and `extract-zip` as optional in `package.json`.
>     - Add `archiver` and `extract-zip` to `dependencies` in `package.json`.
>   - **Error Handling**:
>     - In `RedisStorage.ts`, dynamically import `ioredis`, `archiver`, and `extract-zip` with improved error messages if not installed.
>     - Throw specific errors if dynamic imports fail, suggesting installation commands.
>   - **Misc**:
>     - Remove duplicate type definitions in `RedisStorage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=bigboateng%2Fbrowserstate&utm_source=github&utm_medium=referral)<sup> for c403456b1f89e7a550b83a489dd80886f205d6b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->